### PR TITLE
BUG: Fixed new segment color after last segment has been removed

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -1150,7 +1150,7 @@ void vtkMRMLSegmentationDisplayNode::UpdateSegmentList()
     }
   if (this->SegmentListUpdateSource == segmentation && this->SegmentListUpdateTime >= segmentation->GetMTime())
     {
-    // already up-to-date
+    // Already up-to-date
     return;
     }
   this->SegmentListUpdateTime = segmentation->GetMTime();
@@ -1159,6 +1159,12 @@ void vtkMRMLSegmentationDisplayNode::UpdateSegmentList()
   // Disable modified event, as we just update internal cache
   bool wasDisableModified = this->GetDisableModifiedEvent();
   this->SetDisableModifiedEvent(true);
+
+  // Reset number of generated colors if last segment was removed
+  if (segmentation->GetNumberOfSegments() == 0)
+    {
+    this->NumberOfGeneratedColors = 0;
+    }
 
   // Remove unused segment display properties and colors
   // Get list of segment IDs that we have display properties for but does not exist in
@@ -1169,7 +1175,7 @@ void vtkMRMLSegmentationDisplayNode::UpdateSegmentList()
     {
     if (segmentation->GetSegment(it->first) == NULL)
       {
-      // the segment does not exist in segmentation
+      // The segment does not exist in segmentation
       orphanSegmentIds.push_back(it->first);
       }
     }

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
@@ -277,6 +277,8 @@ protected:
   vtkMRMLSegmentationDisplayNode(const vtkMRMLSegmentationDisplayNode&);
   void operator=(const vtkMRMLSegmentationDisplayNode&);
 
+  friend class vtkMRMLSegmentationNode; // Access to UpdateSegmentList();
+
 protected:
   /// Name of representation that is displayed in 2D views as outline or filled area
   /// if exists. If does not exist, then master representation is displayed.

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -75,6 +75,7 @@ vtkMRMLSegmentationNode::vtkMRMLSegmentationNode()
 vtkMRMLSegmentationNode::~vtkMRMLSegmentationNode()
 {
   this->SetAndObserveSegmentation(NULL);
+
   // Make sure this callback cannot call this object
   this->SegmentationModifiedCallbackCommand->SetClientData(NULL);
 }
@@ -264,11 +265,24 @@ void vtkMRMLSegmentationNode::OnMasterRepresentationModified()
 //---------------------------------------------------------------------------
 void vtkMRMLSegmentationNode::OnSegmentAdded(const char* vtkNotUsed(segmentId))
 {
+  vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(this->GetDisplayNode());
+  if (displayNode)
+    {
+    // Make sure the properties of the new segment are as expected even before the first update is triggered (e.g. by slice controller widget)
+    displayNode->UpdateSegmentList();
+    }
 }
 
 //---------------------------------------------------------------------------
 void vtkMRMLSegmentationNode::OnSegmentRemoved(const char* vtkNotUsed(segmentId))
 {
+  vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(this->GetDisplayNode());
+  if (displayNode)
+    {
+    // Make sure the segment is removed from the display properties as well, so that when a new segment is added
+    // in its place it is properly populated (it will have the same segment ID, so it would simply claim it)
+    displayNode->UpdateSegmentList();
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -411,10 +425,10 @@ void vtkMRMLSegmentationNode::ApplyTransform(vtkAbstractTransform* transform)
   char* preferredDisplayRepresentation3D = NULL;
   vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(this->GetDisplayNode());
   if (displayNode)
-  {
+    {
     preferredDisplayRepresentation2D = displayNode->GetPreferredDisplayRepresentationName2D();
     preferredDisplayRepresentation3D = displayNode->GetPreferredDisplayRepresentationName3D();
-  }
+    }
 
   // Make sure preferred display representations exist after transformation
   // (it was invalidated in the process unless it is the master representation)

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
@@ -1194,7 +1194,6 @@ void vtkSubjectHierarchyItem::ReparentChildrenToParent()
     }
 
   this->Parent->Modified();
-  this->Modified();
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -421,9 +421,9 @@ void qMRMLSegmentsTableView::populateSegmentTable()
     // in the selected terminology entry. This color is the same as the one generated for the empty segment
     double generatedColorArray[3] = {0.5,0.5,0.5};
     if (displayNode)
-    {
+      {
       displayNode->GenerateSegmentColor(generatedColorArray, segmentation->GetSegmentIndex(segmentId.toLatin1().constData()) + 1);
-    }
+      }
     QColor generatedColor = QColor::fromRgbF(generatedColorArray[0], generatedColorArray[1], generatedColorArray[2]);
     // Set item data
     colorItem->setData(Qt::DecorationRole, color);


### PR DESCRIPTION
If the last segment has been removed (and it was Segment_1), then the display node still contains the properties of Segment_1 until an update is triggered (for example by slice controller widget, but it depends on what the user does). But the segment ID generator index in vtkSegmentation is also reset to 0, so the new segment will be Segment_1, which simply "claims" those display properties. However, a new segment color is then not generated, so it will be gray. The implemented solution explicitly calls the update function when a segment is removed or added. The number of generated colors is also reset in the display node so that the colors for the subsequent segments are the same.

An unnecessary modified was removed from subject hierarchy node that resulted in an error message when there was no error.

git-svn-id: http://svn.slicer.org/Slicer4/trunk@26654 3bd1e089-480b-0410-8dfb-8563597acbee